### PR TITLE
Updated incidents table in schema.sql

### DIFF
--- a/database/schema.sql
+++ b/database/schema.sql
@@ -75,14 +75,14 @@ CREATE TABLE operator_subscriptions (
 CREATE TABLE incidents (
     incident_id SERIAL PRIMARY KEY,
     operator_id INT REFERENCES operators(operator_id),
+    incident_uuid VARCHAR(32) NOT NULL,
     creation_date TIMESTAMP NOT NULL,
-    description TEXT,
-    summary TEXT,
+    last_updated TIMESTAMP NOT NULL,
     start_date TIMESTAMP NOT NULL,
     end_date TIMESTAMP,
-    info_link TEXT,
+    is_planned BOOLEAN NOT NULL,
+    is_cleared BOOLEAN NOT NULL,
     affected_routes TEXT,
-    planned BOOLEAN NOT NULL,
-    incident_uuid VARCHAR(32) UNIQUE NOT NULL,
-    last_updated TIMESTAMP NOT NULL
+    summary TEXT NOT NULL,
+    info_link TEXT
 );


### PR DESCRIPTION
## Updated incident table of schema script
I have updated the incidents table: it no longer stores the description as I thought this was unnecessary since it already stores a summary. I have also added `is_cleared` which is a boolean value indicating whether or not an incident has cleared. I thought this would be a useful indicator to differentiate between ongoing and resolved incidents. 

## Updated ERD diagram
Reflecting the changes above, I have edited the ERD diagram and updated the README.
