### PR TITLE
[Bug] Fixed Line 4 Typo in historical_schema.sql

### DIFF
--- a/database/historical_schema.sql
+++ b/database/historical_schema.sql
@@ -1,7 +1,7 @@
 DROP TABLE IF EXISTS archive.station_performance;
 DROP TABLE IF EXISTS archive.operator_performance;
 
-CREATE TABLE historical_data.station_performance(
+CREATE TABLE archive.station_performance(
     station_performance_id SERIAL PRIMARY KEY,
     station_id INT REFERENCES public.stations(station_id),
     day DATE NOT NULL,


### PR DESCRIPTION
I have fixed the line 4 typo in the historical_schema.sql file (changing schema from historical_data to archive). 

Closes #106 