### PR TITLE
Set timezone in docker container to match local time

### DIFF
--- a/incidents/Dockerfile
+++ b/incidents/Dockerfile
@@ -1,5 +1,9 @@
 FROM python:latest
 
+ENV TZ=Europe/London
+
+RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
+
 COPY requirements.txt .
 
 RUN pip3 install -r requirements.txt


### PR DESCRIPTION
##Updated Dockerfile
- added two lines to Dockerfile to set timezone to be the same as local machine time zone.